### PR TITLE
made spago and purescript optional (provided); providing basic shell.nix

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.4",
+    "rimraf": "^3.0.0"
+  },
+  "optionalDependencies": {
     "purescript": "^0.13.5",
-    "rimraf": "^3.0.0",
     "spago": "^0.12.1"
   }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    buildInputs = [ pkgs.spago pkgs.nodejs pkgs.purescript ];
+}


### PR DESCRIPTION
NPM doesn't have the concept of provided dependencies, but we can make dependencies optional. If there is a failure installing the optional dependencies, it won't cause a failure overall. Binaries distributed via npm are a problem on certain OSes (e.g. NixOS) that have somwhat different linking conventions than most Linux distributions. As far as I can tell, this shouldn't affect users not on Nix-based environments (including in my testing).

I also provide a very basic (strictly optional) shell.nix to load the required binaries.